### PR TITLE
fix: 扫描完整的 2bpp 帧缓冲变化

### DIFF
--- a/firmware/main/boards/zectrix-s3-epaper-4.2/custom_lcd_display.cc
+++ b/firmware/main/boards/zectrix-s3-epaper-4.2/custom_lcd_display.cc
@@ -313,7 +313,9 @@ static FrameDiffResult analyze_frame_diff(
         return result;
     }
 
-    const int bytes_per_row = (width + 7) >> 3;
+    // RawDraw always keeps a 2bpp semantic framebuffer, including when a
+    // 1bpp panel is selected and down-converted before transmission.
+    const int bytes_per_row = (width * 2 + 7) >> 3;
     const size_t total_bytes = bytes_per_row * height;
     const size_t total_bits = total_bytes * 8;
 


### PR DESCRIPTION
## 问题

Note 4C 的 RawDraw 语义帧缓冲始终按 2bpp 保存：400 × 300 画面占 30,000 字节。当前 `analyze_frame_diff()` 却使用 1bpp 的行字节数公式 `(width + 7) >> 3`，因此只会比较前 15,000 字节。

当变化只出现在帧缓冲后半段时，差异分析可能错误返回“无变化”；调用方随后把 `refresh_needed` 设为 `false`，从而跳过本应执行的刷新。

## 根因

差异分析使用的步长与实际语义帧缓冲格式不一致。即使选择 1bpp 面板，内部帧缓冲仍保持 2bpp，只在发送到面板前做降位转换。

## 修改

- 将差异分析的行字节数改为 2bpp 公式 `(width * 2 + 7) >> 3`。
- 增加注释，说明语义帧缓冲与面板传输格式的区别。
- 不改变刷新波形、调度策略或面板传输流程。

## 验证

- ESP-IDF v6.0.0，目标 `esp32s3`：完整构建通过（2485/2485）。
- 生成的 `xiaozhi.bin` 大小为 `0x2b8f00`，应用分区剩余 31%。
- 派生固件的主机回归测试已覆盖帧缓冲最后一个字节、最后一行变化以及无效参数回退。
- Note 4C 真机上的正常全刷和按键触发刷新均已验证。

## 验证边界

尚未在真机上单独构造“只有帧缓冲后半段发生变化”的隔离场景；因此先以 Draft 提交，便于维护者复核这一处格式修正。
