### PR TITLE
fix: 配网成功前等待 DHCP 分配地址

### DIFF
--- a/firmware/main/components/78__esp-wifi-connect/wifi_configuration_ap.cc
+++ b/firmware/main/components/78__esp-wifi-connect/wifi_configuration_ap.cc
@@ -21,8 +21,8 @@
 
 #define TAG "WifiConfigurationAp"
 
-#define WIFI_CONNECTED_BIT BIT0
-#define WIFI_FAIL_BIT      BIT1
+#define WIFI_GOT_IP_BIT BIT0
+#define WIFI_FAIL_BIT   BIT1
 
 extern const char index_html_start[] asm("_binary_wifi_configuration_html_start");
 extern const char done_html_start[] asm("_binary_wifi_configuration_done_html_start");
@@ -707,7 +707,7 @@ bool WifiConfigurationAp::ConnectToWifi(const std::string &ssid, const std::stri
     
     is_connecting_ = true;
     esp_wifi_scan_stop();
-    xEventGroupClearBits(event_group_, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
+    xEventGroupClearBits(event_group_, WIFI_GOT_IP_BIT | WIFI_FAIL_BIT);
 
     wifi_config_t wifi_config;
     bzero(&wifi_config, sizeof(wifi_config));
@@ -728,7 +728,7 @@ bool WifiConfigurationAp::ConnectToWifi(const std::string &ssid, const std::stri
     // Wait for the connection to complete for 10 or 25 seconds
     EventBits_t bits = xEventGroupWaitBits(
         event_group_,
-        WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+        WIFI_GOT_IP_BIT | WIFI_FAIL_BIT,
         pdTRUE,
         pdFALSE,
 #ifdef CONFIG_SOC_WIFI_SUPPORT_5G
@@ -739,7 +739,7 @@ bool WifiConfigurationAp::ConnectToWifi(const std::string &ssid, const std::stri
     );
     is_connecting_ = false;
 
-    if (bits & WIFI_CONNECTED_BIT) {
+    if (bits & WIFI_GOT_IP_BIT) {
         ESP_LOGI(TAG, "Connected to WiFi %s", ssid.c_str());
         esp_wifi_disconnect();
         return true;
@@ -770,7 +770,7 @@ void WifiConfigurationAp::WifiEventHandler(void* arg, esp_event_base_t event_bas
         wifi_event_ap_stadisconnected_t* event = (wifi_event_ap_stadisconnected_t*) event_data;
         ESP_LOGI(TAG, "Station " MACSTR " left, AID=%d", MAC2STR(event->mac), event->aid);
     } else if (event_id == WIFI_EVENT_STA_CONNECTED) {
-        xEventGroupSetBits(self->event_group_, WIFI_CONNECTED_BIT);
+        ESP_LOGI(TAG, "Associated with WiFi, waiting for IP address");
     } else if (event_id == WIFI_EVENT_STA_DISCONNECTED) {
         xEventGroupSetBits(self->event_group_, WIFI_FAIL_BIT);
     } else if (event_id == WIFI_EVENT_SCAN_DONE) {
@@ -792,7 +792,7 @@ void WifiConfigurationAp::IpEventHandler(void* arg, esp_event_base_t event_base,
     if (event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
         ESP_LOGI(TAG, "Got IP:" IPSTR, IP2STR(&event->ip_info.ip));
-        xEventGroupSetBits(self->event_group_, WIFI_CONNECTED_BIT);
+        xEventGroupSetBits(self->event_group_, WIFI_GOT_IP_BIT);
     }
 }
 


### PR DESCRIPTION
## 问题

配网页面提交家庭 Wi-Fi 后，`ConnectToWifi()` 当前把 `WIFI_EVENT_STA_CONNECTED` 当作连接成功。这个事件只表示 STA 已完成 802.11 关联，并不表示 DHCP 已经分配 IP 地址。

函数在收到该事件后会立刻调用 `esp_wifi_disconnect()` 并返回成功，因此页面可能显示“连接成功”，实际设备却尚未取得可用地址，保存后的网络也未被真正验证。

## 根因

同一个 `WIFI_CONNECTED_BIT` 同时由 `WIFI_EVENT_STA_CONNECTED` 和 `IP_EVENT_STA_GOT_IP` 设置，把“已关联”和“已取得 IP”两个不同阶段合并成了一个成功条件。

## 修改

- 将成功事件位明确命名为 `WIFI_GOT_IP_BIT`。
- `WIFI_EVENT_STA_CONNECTED` 只记录“已关联，等待 IP”，不再提前宣告成功。
- 仅在收到 `IP_EVENT_STA_GOT_IP` 后设置成功事件位。
- 保持原有的 10 秒 / 25 秒超时、失败事件和后续断开流程不变。

## 验证

- ESP-IDF v6.0.0，目标 `esp32s3`：工程构建通过。
- 生成的 `xiaozhi.bin` 大小为 `0x2b8f60`，应用分区剩余 31%。
- 派生固件的主机回归测试已覆盖事件顺序：只有 `STA_CONNECTED` 时不返回成功，收到 `GOT_IP` 后才完成。
- Note 4C 真机已走通 SoftAP 配网页面、目标 Wi-Fi DHCP、保存配置并返回正常页面的完整流程。

## 验证边界

真机验证使用的是包含同一修复的派生固件，并非单独烧录本分支生成的最小镜像。为保持修改范围清晰，本 PR 没有调整既有 DHCP 等待超时。
