### PR TITLE
fix: WiFi hidden-SSID reconnect, modem sleep, and OTA rollback validation

### DIFF
--- a/firmware/main/components/78__esp-wifi-connect/include/wifi_station.h
+++ b/firmware/main/components/78__esp-wifi-connect/include/wifi_station.h
@@ -101,7 +101,15 @@ private:
     std::vector<WifiApRecord> connect_queue_;
     bool was_connected_ = false;  // Track if we were connected before disconnection
 
+    // Hidden APs don't answer the wildcard scan below, only a probe request
+    // that names them directly. When a wildcard scan finds none of the saved
+    // SSIDs, we walk this queue and issue one directed scan per saved SSID.
+    std::vector<std::string> hidden_probe_queue_;
+    std::string hidden_probe_current_ssid_;
+    bool hidden_probe_active_ = false;
+
     void HandleScanResult();
+    bool StartNextHiddenProbe();
     void StartConnect();
     void UpdateScanInterval();  // Exponential backoff for scan interval
     void HandleFastFallback(const char* reason, int reason_id);

--- a/firmware/main/components/78__esp-wifi-connect/wifi_station.cc
+++ b/firmware/main/components/78__esp-wifi-connect/wifi_station.cc
@@ -792,6 +792,13 @@ void WifiStation::Start() {
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_start());
 
+    // Modem sleep (the ESP-IDF station default) buffers/drops incoming
+    // packets between DTIM beacons, which shows up as slow TCP handshakes
+    // and a high HTTP failure rate. Boot with full radio power and let
+    // SetPowerSaveLevel() dial it back down if the user opts into LOW_POWER
+    // or BALANCED from Settings.
+    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
+
     if (max_tx_power_ != 0) {
         ESP_ERROR_CHECK(esp_wifi_set_max_tx_power(max_tx_power_));
     }
@@ -836,7 +843,7 @@ void WifiStation::HandleScanResult() {
         });
         if (it != ssid_list.end()) {
             ESP_LOGI(TAG, "Found AP: %s, BSSID: %02x:%02x:%02x:%02x:%02x:%02x, RSSI: %d, Channel: %d, Authmode: %d",
-                (char *)ap_record.ssid, 
+                (char *)ap_record.ssid,
                 ap_record.bssid[0], ap_record.bssid[1], ap_record.bssid[2],
                 ap_record.bssid[3], ap_record.bssid[4], ap_record.bssid[5],
                 ap_record.rssi, ap_record.primary, ap_record.authmode);

--- a/firmware/main/components/78__esp-wifi-connect/wifi_station.cc
+++ b/firmware/main/components/78__esp-wifi-connect/wifi_station.cc
@@ -683,6 +683,8 @@ void WifiStation::Stop() {
     force_scan_ = false;
     ip_fast_attempt_ = false;
     ip_fast_ready_ = false;
+    hidden_probe_active_ = false;
+    hidden_probe_queue_.clear();
 
     // Clear connected bit
     xEventGroupClearBits(event_group_, WIFI_EVENT_CONNECTED);
@@ -827,8 +829,10 @@ bool WifiStation::WaitForConnected(int timeout_ms) {
 void WifiStation::HandleScanResult() {
     uint16_t ap_num = 0;
     esp_wifi_scan_get_ap_num(&ap_num);
-    wifi_ap_record_t *ap_records = (wifi_ap_record_t *)malloc(ap_num * sizeof(wifi_ap_record_t));
-    esp_wifi_scan_get_ap_records(&ap_num, ap_records);
+    wifi_ap_record_t *ap_records = ap_num > 0 ? (wifi_ap_record_t *)malloc(ap_num * sizeof(wifi_ap_record_t)) : nullptr;
+    if (ap_num > 0) {
+        esp_wifi_scan_get_ap_records(&ap_num, ap_records);
+    }
     // sort by rssi descending
     std::sort(ap_records, ap_records + ap_num, [](const wifi_ap_record_t& a, const wifi_ap_record_t& b) {
         return a.rssi > b.rssi;
@@ -860,14 +864,53 @@ void WifiStation::HandleScanResult() {
     }
     free(ap_records);
 
-    if (connect_queue_.empty()) {
-        ESP_LOGI(TAG, "No AP found, next scan in %d seconds", scan_current_interval_microseconds_ / 1000 / 1000);
-        esp_timer_start_once(timer_handle_, scan_current_interval_microseconds_);
-        UpdateScanInterval();
+    if (!connect_queue_.empty()) {
+        hidden_probe_queue_.clear();
+        hidden_probe_active_ = false;
+        StartConnect();
         return;
     }
 
-    StartConnect();
+    // The wildcard scan above found none of our saved SSIDs. A hidden AP
+    // never answers that scan -- it only answers a probe request that names
+    // it directly -- so before giving up, walk every saved SSID with one
+    // directed scan each. If this callback *is* one of those directed
+    // probes and it still found nothing, StartNextHiddenProbe() advances the
+    // queue for us.
+    if (!hidden_probe_active_) {
+        hidden_probe_queue_.clear();
+        for (const auto& item : ssid_list) {
+            hidden_probe_queue_.push_back(item.ssid);
+        }
+    }
+    if (StartNextHiddenProbe()) {
+        return;
+    }
+
+    hidden_probe_active_ = false;
+    ESP_LOGI(TAG, "No AP found, next scan in %d seconds", scan_current_interval_microseconds_ / 1000 / 1000);
+    esp_timer_start_once(timer_handle_, scan_current_interval_microseconds_);
+    UpdateScanInterval();
+}
+
+bool WifiStation::StartNextHiddenProbe() {
+    if (hidden_probe_queue_.empty()) {
+        return false;
+    }
+    hidden_probe_current_ssid_ = hidden_probe_queue_.front();
+    hidden_probe_queue_.erase(hidden_probe_queue_.begin());
+    hidden_probe_active_ = true;
+
+    wifi_scan_config_t scan_config = {};
+    scan_config.ssid = reinterpret_cast<uint8_t*>(hidden_probe_current_ssid_.data());
+    scan_config.show_hidden = true;
+    ESP_LOGI(TAG, "Probing hidden SSID candidate: \"%s\"", hidden_probe_current_ssid_.c_str());
+    esp_err_t err = esp_wifi_scan_start(&scan_config, false);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Hidden SSID probe scan failed to start: %s", esp_err_to_name(err));
+        return StartNextHiddenProbe();
+    }
+    return true;
 }
 
 void WifiStation::StartConnect() {

--- a/firmware/main/main.cc
+++ b/firmware/main/main.cc
@@ -1,5 +1,6 @@
 #include <esp_log.h>
 #include <esp_err.h>
+#include <esp_ota_ops.h>
 #include <nvs.h>
 #include <nvs_flash.h>
 #include <driver/gpio.h>
@@ -35,6 +36,22 @@ static void LogNvsStats() {
 
 extern "C" void app_main(void)
 {
+    // Bootloader app-rollback is enabled (ota_0/ota_1), which boots each new
+    // image in the "pending verify" state and reverts to the previous slot
+    // after enough reboots unless something marks it valid. Nothing else in
+    // this firmware calls esp_ota_mark_app_valid_cancel_rollback(), so every
+    // OTA update was silently rolling back a few reboots after flashing.
+    {
+        esp_ota_img_states_t ota_state;
+        const esp_partition_t* running = esp_ota_get_running_partition();
+        if (running != nullptr &&
+            esp_ota_get_state_partition(running, &ota_state) == ESP_OK &&
+            ota_state == ESP_OTA_IMG_PENDING_VERIFY) {
+            esp_ota_mark_app_valid_cancel_rollback();
+            ESP_LOGI(TAG, "Marked running app valid, rollback cancelled");
+        }
+    }
+
     // Some soft/external reset paths leave the Wi-Fi RF state dirty until the
     // next hardware-equivalent reset. For those reset reasons only, perform a
     // brief deep-sleep round-trip once to come back with clean radio state.


### PR DESCRIPTION
## Summary
Three independent reliability fixes found and fixed in the same session, split out from the i18n branch they were previously bundled with:

- **fix: mark running app valid to cancel OTA rollback** — bootloader app-rollback is enabled (ota_0/ota_1) but nothing ever called `esp_ota_mark_app_valid_cancel_rollback()`, so every freshly flashed image stayed in `PENDING_VERIFY` and would roll back to the previous image on the next unrelated reset.
- **fix: disable WiFi modem sleep on station start** — ESP-IDF's default station power-save mode buffers/drops incoming packets between DTIM beacons, showing up as slow TCP handshakes and dropped connections.
- **fix(wifi): probe saved SSIDs directly to reconnect to hidden APs** — hidden APs don't respond to the wildcard scan `WifiStation` used for reconnect, only to a directed probe request naming them explicitly.

## Test plan
- [x] Built and flashed to hardware.
